### PR TITLE
Added columns 'gateway' and 'ip_address' to the table

### DIFF
--- a/simple-membership/classes/admin-includes/class.swpm-payments-list-table.php
+++ b/simple-membership/classes/admin-includes/class.swpm-payments-list-table.php
@@ -90,7 +90,9 @@ class SWPMPaymentsListTable extends WP_List_Table {
 			'subscr_id'        => SwpmUtils::_( 'Subscriber ID' ),
 			'payment_amount'   => SwpmUtils::_( 'Amount' ),
 			'membership_level' => SwpmUtils::_( 'Membership Level' ),
-                        'status' => SwpmUtils::_( 'Status/Note' ),
+			'gateway'          => SwpmUtils::_( 'Gateway' ),
+			'status'           => SwpmUtils::_( 'Status/Note' ),
+			'ip_address'       => SwpmUtils::_( 'IP Address' ),
 		);
 		return $columns;
 	}


### PR DESCRIPTION
I find useful to see the gateway and ip_address for the payments.

So I've added the columns 'gateway and 'ip_address' to the HTML table, in the WP Admin area, in "Simple Membership::Payments" page.

Visible at this URL : https://<site_url>/wp-admin/admin.php?page=simple_wp_membership_payments

Thanks