### PR TITLE
Added option 'use-automatic-username' to be able to enable/disable the automatic username generation

### DIFF
--- a/simple-membership/classes/class.swpm-settings.php
+++ b/simple-membership/classes/class.swpm-settings.php
@@ -725,6 +725,18 @@ class SwpmSettings {
 			)
 		);
 
+		add_settings_field(
+			'use-automatic-username',
+			SwpmUtils::_( 'Use Automatic Usernames' ),
+			array( &$this, 'checkbox_callback' ),
+			'simple_wp_membership_settings',
+			'advanced-settings',
+			array(
+				'item'    => 'use-automatic-username',
+				'message' => SwpmUtils::_( 'Enable this option if you want to automatically generate the Usernames and therefore hide the Username field from users. Since the Usernames have to be unique, the plugin will use the current date+time to generate a unique number. The automatic Username will be YYMMDDHHmmXXXX, with XXXX being a 4-digit long random number. Example for an user creating an account on July 25th 2020 at 8:55 AM : 20072508551234.' ),
+			)
+		);
+
 		//Auto create SWPM user related settings section
 		add_settings_section( 'auto-create-swpm-user-settings', SwpmUtils::_( 'Create Member Accounts for New WP Users' ), array( &$this, 'advanced_settings_auto_create_swpm_uses_settings_callback' ), 'simple_wp_membership_settings' );
 
@@ -1145,9 +1157,10 @@ class SwpmSettings {
 		$output['after-logout-redirection-url']      = esc_url( $input['after-logout-redirection-url'] );
 		$output['force-strong-passwords']            = isset( $input['force-strong-passwords'] ) ? esc_attr( $input['force-strong-passwords'] ) : '';
 		$output['auto-login-after-rego']             = isset( $input['auto-login-after-rego'] ) ? esc_attr( $input['auto-login-after-rego'] ) : '';
-                $output['hide-rego-form-to-logged-users']    = isset( $input['hide-rego-form-to-logged-users'] ) ? esc_attr( $input['hide-rego-form-to-logged-users'] ) : '';
+		$output['hide-rego-form-to-logged-users']    = isset( $input['hide-rego-form-to-logged-users'] ) ? esc_attr( $input['hide-rego-form-to-logged-users'] ) : '';
 		$output['force-wp-user-sync']                = isset( $input['force-wp-user-sync'] ) ? esc_attr( $input['force-wp-user-sync'] ) : '';
 		$output['payment-notification-forward-url']  = esc_url( $input['payment-notification-forward-url'] );
+		$output['use-automatic-username']            = esc_url( $input['use-automatic-username'] );
 
 		//Auto create swpm user related settings
 		$output['enable-auto-create-swpm-members']      = isset( $input['enable-auto-create-swpm-members'] ) ? esc_attr( $input['enable-auto-create-swpm-members'] ) : '';

--- a/simple-membership/classes/class.swpm-settings.php
+++ b/simple-membership/classes/class.swpm-settings.php
@@ -1160,7 +1160,7 @@ class SwpmSettings {
 		$output['hide-rego-form-to-logged-users']    = isset( $input['hide-rego-form-to-logged-users'] ) ? esc_attr( $input['hide-rego-form-to-logged-users'] ) : '';
 		$output['force-wp-user-sync']                = isset( $input['force-wp-user-sync'] ) ? esc_attr( $input['force-wp-user-sync'] ) : '';
 		$output['payment-notification-forward-url']  = esc_url( $input['payment-notification-forward-url'] );
-		$output['use-automatic-username']            = esc_url( $input['use-automatic-username'] );
+		$output['use-automatic-username']            = isset( $input['use-automatic-username'] ) ? esc_attr( $input['use-automatic-username'] ) : '';
 
 		//Auto create swpm user related settings
 		$output['enable-auto-create-swpm-members']      = isset( $input['enable-auto-create-swpm-members'] ) ? esc_attr( $input['enable-auto-create-swpm-members'] ) : '';

--- a/simple-membership/views/add.php
+++ b/simple-membership/views/add.php
@@ -7,12 +7,22 @@ if (!empty($force_strong_pass)) {
 } else {
     $pass_class = "";
 }
+
+// Get value of use-automatic-username to detect if we want to generate usernames automatically and hide the username field or not
+$use_automatic_username = $settings->get_value('use-automatic-username');
+// If the option is enabled, generate the username automatically and enable the hidden attribute (so it will hide the username field)
+if (!empty($use_automatic_username)) {
+    $user_name=date('ymdHi').mt_rand(1000, 9999);
+    $hidden_username_attribute="hidden";
+} else { // If the option is not enabled, do not enable the hidden attribute (so it will show the username field)
+    $hidden_username_attribute="";
+}
 ?>
 <div class="swpm-registration-widget-form">
     <form id="swpm-registration-form" class="swpm-validate-form" name="swpm-registration-form" method="post" action="">
         <input type ="hidden" name="level_identifier" value="<?php echo $level_identifier ?>" />
         <table>
-            <tr class="swpm-registration-username-row">
+            <tr class="swpm-registration-username-row" <?php echo $hidden_username_attribute ?>>
                 <td><label for="user_name"><?php echo SwpmUtils::_('Username') ?></label></td>
                 <td><input type="text" id="user_name" class="validate[required,custom[noapostrophe],custom[SWPMUserName],minSize[4],ajax[ajaxUserCall]]" value="<?php echo esc_attr($user_name); ?>" size="50" name="user_name" /></td>
             </tr>

--- a/simple-membership/views/add.php
+++ b/simple-membership/views/add.php
@@ -8,14 +8,10 @@ if (!empty($force_strong_pass)) {
     $pass_class = "";
 }
 
-// Get value of use-automatic-username to detect if we want to generate usernames automatically and hide the username field or not
-$use_automatic_username = $settings->get_value('use-automatic-username');
-// If the option is enabled, generate the username automatically and enable the hidden attribute (so it will hide the username field)
-if (!empty($use_automatic_username)) {
+// If the option use-automatic-usernam is enabled, generate the username automatically and set the attribute to hidden (so it will hide the username field)
+if (!empty($settings->get_value('use-automatic-username'))) {
     $user_name=date('ymdHi').mt_rand(1000, 9999);
     $hidden_username_attribute="hidden";
-} else { // If the option is not enabled, do not enable the hidden attribute (so it will show the username field)
-    $hidden_username_attribute="";
 }
 ?>
 <div class="swpm-registration-widget-form">

--- a/simple-membership/views/add.php
+++ b/simple-membership/views/add.php
@@ -8,7 +8,7 @@ if (!empty($force_strong_pass)) {
     $pass_class = "";
 }
 
-// If the option use-automatic-usernam is enabled, generate the username automatically and set the attribute to hidden (so it will hide the username field)
+// If the option use-automatic-username is enabled, generate the username automatically and set the attribute to hidden (so it will hide the username field)
 if (!empty($settings->get_value('use-automatic-username'))) {
     $user_name=date('ymdHi').mt_rand(1000, 9999);
     $hidden_username_attribute="hidden";

--- a/simple-membership/views/edit.php
+++ b/simple-membership/views/edit.php
@@ -11,14 +11,8 @@ if (!empty($force_strong_pass)) {
     $pass_class="";
 }
 
-// Get value of use-automatic-username to detect if we want to hide the username field or not
-$use_automatic_username = $settings->get_value('use-automatic-username');
-// If the option is enabled, enable the hidden attribute (so it will hide the username field)
-if (!empty($use_automatic_username)) {
-    $hidden_username_attribute="hidden";
-} else { // If the option is not enabled, do not enable the hidden attribute (so it will show the username field)
-    $hidden_username_attribute="";
-}
+// If the option use-automatic-username is enabled, set the attribute to hidden (so it will hide the username field)
+$hidden_username_attribute  = !empty($settings->get_value('use-automatic-username')) ? 'hidden' : '';
 
 SimpleWpMembership::enqueue_validation_scripts();
 //The admin ajax causes an issue with the JS validation if done on form submission. The edit profile doesn't need JS validation on email. There is PHP validation which will catch any email error.

--- a/simple-membership/views/edit.php
+++ b/simple-membership/views/edit.php
@@ -10,6 +10,16 @@ if (!empty($force_strong_pass)) {
 } else {
     $pass_class="";
 }
+
+// Get value of use-automatic-username to detect if we want to hide the username field or not
+$use_automatic_username = $settings->get_value('use-automatic-username');
+// If the option is enabled, enable the hidden attribute (so it will hide the username field)
+if (!empty($use_automatic_username)) {
+    $hidden_username_attribute="hidden";
+} else { // If the option is not enabled, do not enable the hidden attribute (so it will show the username field)
+    $hidden_username_attribute="";
+}
+
 SimpleWpMembership::enqueue_validation_scripts();
 //The admin ajax causes an issue with the JS validation if done on form submission. The edit profile doesn't need JS validation on email. There is PHP validation which will catch any email error.
 //SimpleWpMembership::enqueue_validation_scripts(array('ajaxEmailCall' => array('extraData'=>'&action=swpm_validate_email&member_id='.SwpmAuth::get_instance()->get('member_id'))));
@@ -19,7 +29,7 @@ SimpleWpMembership::enqueue_validation_scripts();
         <?php wp_nonce_field('swpm_profile_edit_nonce_action', 'swpm_profile_edit_nonce_val') ?>
         <table>
             <?php apply_filters('swpm_edit_profile_form_before_username', ''); ?>
-            <tr class="swpm-profile-username-row">
+            <tr class="swpm-profile-username-row" <?php echo $hidden_username_attribute ?>>
                 <td><label for="user_name"><?php echo SwpmUtils::_('Username'); ?></label></td>
                 <td><?php echo $user_name ?></td>
             </tr>
@@ -70,7 +80,7 @@ SimpleWpMembership::enqueue_validation_scripts();
             <tr class="swpm-profile-company-row">
                 <td><label for="company_name"><?php echo SwpmUtils::_('Company Name'); ?></label></td>
                 <td><input type="text" id="company_name" value="<?php echo $company_name; ?>" size="50" name="company_name" /></td>
-            </tr>            
+            </tr>
             <tr class="swpm-profile-membership-level-row">
                 <td><label for="membership_level"><?php echo SwpmUtils::_('Membership Level'); ?></label></td>
                 <td>

--- a/simple-membership/views/login.php
+++ b/simple-membership/views/login.php
@@ -1,14 +1,17 @@
 <?php
 $auth = SwpmAuth::get_instance();
-$setting = SwpmSettings::get_instance();
-$password_reset_url = $setting->get_value('reset-page-url');
-$join_url = $setting->get_value('join-us-page-url');
+$settings = SwpmSettings::get_instance();
+$password_reset_url = $settings->get_value('reset-page-url');
+$join_url = $settings->get_value('join-us-page-url');
+
+// If the option use-automatic-username is enabled, set the username label to 'Email', if not, keep the usual 'Username or Email'
+$swpm_username_label  = !empty($settings->get_value('use-automatic-username')) ? 'Email' : 'Username or Email';
 ?>
 <div class="swpm-login-widget-form">
     <form id="swpm-login-form" name="swpm-login-form" method="post" action="">
         <div class="swpm-login-form-inner">
             <div class="swpm-username-label">
-                <label for="swpm_user_name" class="swpm-label"><?php echo SwpmUtils::_('Username or Email') ?></label>
+                <label for="swpm_user_name" class="swpm-label"><?php echo SwpmUtils::_($swpm_username_label) ?></label>
             </div>
             <div class="swpm-username-input">
                 <input type="text" class="swpm-text-field swpm-username-field" id="swpm_user_name" value="" size="25" name="swpm_user_name" />
@@ -23,9 +26,7 @@ $join_url = $setting->get_value('join-us-page-url');
                 <span class="swpm-remember-checkbox"><input type="checkbox" name="rememberme" value="checked='checked'"></span>
                 <span class="swpm-rember-label"> <?php echo SwpmUtils::_('Remember Me') ?></span>
             </div>
-            
             <div class="swpm-before-login-submit-section"><?php echo apply_filters('swpm_before_login_form_submit_button', ''); ?></div>
-            
             <div class="swpm-login-submit">
                 <input type="submit" class="swpm-login-form-submit" name="swpm-login" value="<?php echo SwpmUtils::_('Login') ?>"/>
             </div>


### PR DESCRIPTION
Hi,

In this PR I've added an option that allow to automatically generate the usernames.

When enabled, the usernames will be automatically populated by the plugin, and the field "username" will be hidden on the User Creation and User Edit form.

The format of the automatically generated usernames is based on the current date/time + a 4 digit long random number : YYMMDDHHmmXXXX

Example for an user creating an account on July 25th 2020 at 8:55 AM : 20072508551234

Thanks

Thomas