### PR TITLE
Added apply_filters to allow external plugins hooks

### DIFF
--- a/simple-membership/views/add.php
+++ b/simple-membership/views/add.php
@@ -7,14 +7,16 @@ if (!empty($force_strong_pass)) {
 } else {
     $pass_class = "";
 }
+// Filter allowing to change the default value of user_name
+$user_name = apply_filters('swpm_registration_form_set_username', $user_name);
 ?>
 <div class="swpm-registration-widget-form">
     <form id="swpm-registration-form" class="swpm-validate-form" name="swpm-registration-form" method="post" action="">
         <input type ="hidden" name="level_identifier" value="<?php echo $level_identifier ?>" />
         <table>
-            <tr class="swpm-registration-username-row">
+            <tr class="swpm-registration-username-row" <?php apply_filters('swpm_registration_form_username_tr_attributes', ''); ?>>
                 <td><label for="user_name"><?php echo SwpmUtils::_('Username') ?></label></td>
-                <td><input type="text" id="user_name" class="validate[required,custom[noapostrophe],custom[SWPMUserName],minSize[4],ajax[ajaxUserCall]]" value="<?php echo esc_attr($user_name); ?>" size="50" name="user_name" /></td>
+                <td><input type="text" id="user_name" class="validate[required,custom[noapostrophe],custom[SWPMUserName],minSize[4],ajax[ajaxUserCall]]" value="<?php echo esc_attr($user_name); ?>" size="50" name="user_name" <?php apply_filters('swpm_registration_form_username_input_attributes', ''); ?>/></td>
             </tr>
             <tr class="swpm-registration-email-row">
                 <td><label for="email"><?php echo SwpmUtils::_('Email') ?></label></td>
@@ -28,15 +30,15 @@ if (!empty($force_strong_pass)) {
                 <td><label for="password_re"><?php echo SwpmUtils::_('Repeat Password') ?></label></td>
                 <td><input type="password" autocomplete="off" id="password_re" value="" size="50" name="password_re" /></td>
             </tr>
-            <tr class="swpm-registration-firstname-row">
+            <tr class="swpm-registration-firstname-row" <?php apply_filters('swpm_registration_form_firstname_tr_attributes', ''); ?>>
                 <td><label for="first_name"><?php echo SwpmUtils::_('First Name') ?></label></td>
                 <td><input type="text" id="first_name" value="<?php echo esc_attr($first_name); ?>" size="50" name="first_name" /></td>
             </tr>
-            <tr class="swpm-registration-lastname-row">
+            <tr class="swpm-registration-lastname-row" <?php apply_filters('swpm_registration_form_lastname_tr_attributes', ''); ?>>
                 <td><label for="last_name"><?php echo SwpmUtils::_('Last Name') ?></label></td>
                 <td><input type="text" id="last_name" value="<?php echo esc_attr($last_name); ?>" size="50" name="last_name" /></td>
             </tr>
-            <tr class="swpm-registration-membership-level-row">
+            <tr class="swpm-registration-membership-level-row" <?php apply_filters('swpm_registration_form_membership_level_tr_attributes', ''); ?>>
                 <td><label for="membership_level"><?php echo SwpmUtils::_('Membership Level') ?></label></td>
                 <td>
                     <?php
@@ -55,6 +57,7 @@ if (!empty($force_strong_pass)) {
                 </td>
             </tr>
             <?php
+            apply_filters('swpm_registration_form_before_terms_and_conditions', '');
             //check if we need to display Terms and Conditions checkbox
             $terms_enabled = $settings->get_value('enable-terms-and-conditions');
             if (!empty($terms_enabled)) {

--- a/simple-membership/views/edit.php
+++ b/simple-membership/views/edit.php
@@ -19,7 +19,7 @@ SimpleWpMembership::enqueue_validation_scripts();
         <?php wp_nonce_field('swpm_profile_edit_nonce_action', 'swpm_profile_edit_nonce_val') ?>
         <table>
             <?php apply_filters('swpm_edit_profile_form_before_username', ''); ?>
-            <tr class="swpm-profile-username-row">
+            <tr class="swpm-profile-username-row" <?php apply_filters('swpm_edit_profile_form_username_tr_attributes', ''); ?>>
                 <td><label for="user_name"><?php echo SwpmUtils::_('Username'); ?></label></td>
                 <td><?php echo $user_name ?></td>
             </tr>
@@ -35,48 +35,49 @@ SimpleWpMembership::enqueue_validation_scripts();
                 <td><label for="password_re"><?php echo SwpmUtils::_('Repeat Password'); ?></label></td>
                 <td><input type="password" id="password_re" value="" size="50" name="password_re" autocomplete="off" placeholder="<?php echo SwpmUtils::_('Leave empty to keep the current password'); ?>" /></td>
             </tr>
-            <tr class="swpm-profile-firstname-row">
+            <tr class="swpm-profile-firstname-row" <?php apply_filters('swpm_edit_profile_form_firstname_tr_attributes', ''); ?>>
                 <td><label for="first_name"><?php echo SwpmUtils::_('First Name'); ?></label></td>
                 <td><input type="text" id="first_name" value="<?php echo $first_name; ?>" size="50" name="first_name" /></td>
             </tr>
-            <tr class="swpm-profile-lastname-row">
+            <tr class="swpm-profile-lastname-row" <?php apply_filters('swpm_edit_profile_form_lastname_tr_attributes', ''); ?>>
                 <td><label for="last_name"><?php echo SwpmUtils::_('Last Name'); ?></label></td>
                 <td><input type="text" id="last_name" value="<?php echo $last_name; ?>" size="50" name="last_name" /></td>
             </tr>
-            <tr class="swpm-profile-phone-row">
+            <tr class="swpm-profile-phone-row" <?php apply_filters('swpm_edit_profile_form_phone_tr_attributes', ''); ?>>
                 <td><label for="phone"><?php echo SwpmUtils::_('Phone'); ?></label></td>
                 <td><input type="text" id="phone" value="<?php echo $phone; ?>" size="50" name="phone" /></td>
             </tr>
-            <tr class="swpm-profile-street-row">
+            <tr class="swpm-profile-street-row" <?php apply_filters('swpm_edit_profile_form_street_tr_attributes', ''); ?>>
                 <td><label for="address_street"><?php echo SwpmUtils::_('Street'); ?></label></td>
                 <td><input type="text" id="address_street" value="<?php echo $address_street; ?>" size="50" name="address_street" /></td>
             </tr>
-            <tr class="swpm-profile-city-row">
+            <tr class="swpm-profile-city-row" <?php apply_filters('swpm_edit_profile_form_city_tr_attributes', ''); ?>>
                 <td><label for="address_city"><?php echo SwpmUtils::_('City'); ?></label></td>
                 <td><input type="text" id="address_city" value="<?php echo $address_city; ?>" size="50" name="address_city" /></td>
             </tr>
-            <tr class="swpm-profile-state-row">
+            <tr class="swpm-profile-state-row" <?php apply_filters('swpm_edit_profile_form_state_tr_attributes', ''); ?>>
                 <td><label for="address_state"><?php echo SwpmUtils::_('State'); ?></label></td>
                 <td><input type="text" id="address_state" value="<?php echo $address_state; ?>" size="50" name="address_state" /></td>
             </tr>
-            <tr class="swpm-profile-zipcode-row">
+            <tr class="swpm-profile-zipcode-row" <?php apply_filters('swpm_edit_profile_form_zipcode_tr_attributes', ''); ?>>
                 <td><label for="address_zipcode"><?php echo SwpmUtils::_('Zipcode'); ?></label></td>
                 <td><input type="text" id="address_zipcode" value="<?php echo $address_zipcode; ?>" size="50" name="address_zipcode" /></td>
             </tr>
-            <tr class="swpm-profile-country-row">
+            <tr class="swpm-profile-country-row" <?php apply_filters('swpm_edit_profile_form_country_tr_attributes', ''); ?>>
                 <td><label for="country"><?php echo SwpmUtils::_('Country'); ?></label></td>
                 <td><select id="country" name="country"><?php echo SwpmMiscUtils::get_countries_dropdown($country) ?></select></td>
             </tr>
-            <tr class="swpm-profile-company-row">
+            <tr class="swpm-profile-company-row" <?php apply_filters('swpm_edit_profile_form_company_tr_attributes', ''); ?>>
                 <td><label for="company_name"><?php echo SwpmUtils::_('Company Name'); ?></label></td>
                 <td><input type="text" id="company_name" value="<?php echo $company_name; ?>" size="50" name="company_name" /></td>
             </tr>            
-            <tr class="swpm-profile-membership-level-row">
+            <tr class="swpm-profile-membership-level-row" <?php apply_filters('swpm_edit_profile_form_membership_level_tr_attributes', ''); ?>>
                 <td><label for="membership_level"><?php echo SwpmUtils::_('Membership Level'); ?></label></td>
                 <td>
                     <?php echo $membership_level_alias; ?>
                 </td>
             </tr>
+            <?php apply_filters('swpm_edit_profile_form_after_membership_level', ''); ?>
         </table>
         <?php apply_filters('swpm_edit_profile_form_before_submit', ''); ?>
         <p class="swpm-edit-profile-submit-section">

--- a/simple-membership/views/login.php
+++ b/simple-membership/views/login.php
@@ -3,12 +3,14 @@ $auth = SwpmAuth::get_instance();
 $setting = SwpmSettings::get_instance();
 $password_reset_url = $setting->get_value('reset-page-url');
 $join_url = $setting->get_value('join-us-page-url');
+// Filter allowing to change the default value of username label
+$swpm_username_label = apply_filters('swpm_login_form_set_username_label', 'Username or Email');
 ?>
 <div class="swpm-login-widget-form">
     <form id="swpm-login-form" name="swpm-login-form" method="post" action="">
         <div class="swpm-login-form-inner">
             <div class="swpm-username-label">
-                <label for="swpm_user_name" class="swpm-label"><?php echo SwpmUtils::_('Username or Email') ?></label>
+                <label for="swpm_user_name" class="swpm-label"><?php echo SwpmUtils::_($swpm_username_label) ?></label>
             </div>
             <div class="swpm-username-input">
                 <input type="text" class="swpm-text-field swpm-username-field" id="swpm_user_name" value="" size="25" name="swpm_user_name" />


### PR DESCRIPTION
Hi,

As agreed, I have added some `apply_filters` to the registration / login / profile edit pages.

The goal of those filters is to be able to edit the behavior of the forms, to be able to integrate with the following plugins : 
- SWPM Automatic Username - https://github.com/Th0masL/swpm-automatic-username
- SWPM Mailjet Integration - https://github.com/Th0masL/swpm-mailjet-integration

Those changes are transparent, and will simply allow plugins to hook on those filters.

Let me know if you have any question.

Thomas