### PR TITLE
Added support for swpm_redirect_to during account registration/activation

### DIFF
--- a/simple-membership/classes/class.swpm-front-registration.php
+++ b/simple-membership/classes/class.swpm-front-registration.php
@@ -169,6 +169,17 @@ class SwpmFrontRegistration extends SwpmRegistration {
 				);
 			} else {
 				$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
+
+				// If exist, get the swpm_redirect_to parameter, and add it to the login_page_url variable to allow future redirections
+				$swpm_redirect_to = !empty($_GET['swpm_redirect_to']) ? filter_input(INPUT_GET, 'swpm_redirect_to', FILTER_SANITIZE_ENCODED) : false;
+
+				$login_page_url = add_query_arg(
+					array(
+					    'swpm_redirect_to' => $swpm_redirect_to,
+					),
+				$login_page_url
+				);
+
 				$after_rego_msg = '<div class="swpm-registration-success-msg">' . SwpmUtils::_( 'Registration Successful. ' ) . SwpmUtils::_( 'Please' ) . ' <a href="' . $login_page_url . '">' . SwpmUtils::_( 'Login' ) . '</a></div>';
 				$after_rego_msg = apply_filters( 'swpm_registration_success_msg', $after_rego_msg );
 				$message        = array(
@@ -441,6 +452,16 @@ class SwpmFrontRegistration extends SwpmRegistration {
 	public function email_activation() {
 		$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
 
+		// If exist, get the swpm_redirect_to parameter, and add it to the login_page_url variable to allow future redirections
+		$swpm_redirect_to = !empty($_GET['swpm_redirect_to']) ? filter_input(INPUT_GET, 'swpm_redirect_to', FILTER_SANITIZE_ENCODED) : false;
+
+		$login_page_url = add_query_arg(
+			array(
+				'swpm_redirect_to' => $swpm_redirect_to,
+			),
+			$login_page_url
+		);
+
 		$member_id = FILTER_INPUT( INPUT_GET, 'swpm_member_id', FILTER_SANITIZE_NUMBER_INT );
 
 		$member = SwpmMemberUtils::get_user_by_id( $member_id );
@@ -476,7 +497,7 @@ class SwpmFrontRegistration extends SwpmRegistration {
 
 		$after_rego_url = SwpmSettings::get_instance()->get_value( 'after-rego-redirect-page-url' );
 		$after_rego_url = apply_filters( 'swpm_after_registration_redirect_url', $after_rego_url );
-		if ( ! empty( $after_rego_url ) ) {
+		if ( ! empty( $after_rego_url ) && empty($swpm_redirect_to) ) {
 			//Yes. Need to redirect to this after registration page
 			SwpmLog::log_simple_debug( 'After registration redirect is configured in settings. Redirecting user to: ' . $after_rego_url, true );
 			SwpmMiscUtils::show_temporary_message_then_redirect( $msg, $after_rego_url );
@@ -490,6 +511,16 @@ class SwpmFrontRegistration extends SwpmRegistration {
 
 	public function resend_activation_email() {
 		$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
+
+		// If exist, get the swpm_redirect_to parameter, and add it to the login_page_url variable to allow future redirections
+		$swpm_redirect_to = !empty($_GET['swpm_redirect_to']) ? filter_input(INPUT_GET, 'swpm_redirect_to', FILTER_SANITIZE_ENCODED) : false;
+
+		$login_page_url = add_query_arg(
+			array(
+				'swpm_redirect_to' => $swpm_redirect_to,
+			),
+			$login_page_url
+		);
 
 		$member_id = FILTER_INPUT( INPUT_GET, 'swpm_member_id', FILTER_SANITIZE_NUMBER_INT );
 

--- a/simple-membership/classes/class.swpm-registration.php
+++ b/simple-membership/classes/class.swpm-registration.php
@@ -37,11 +37,14 @@ abstract class SwpmRegistration {
 			update_option( 'swpm_email_activation_data_usr_' . $member_id, $user_data, false );
 			$body                           = $settings->get_value( 'email-activation-mail-body' );
 			$subject                        = $settings->get_value( 'email-activation-mail-subject' );
+			// If exist, get the swpm_redirect_to parameter, and add it to the activation_link variable to allow future redirections
+			$swpm_redirect_to               = !empty($_GET['swpm_redirect_to']) ? filter_input(INPUT_GET, 'swpm_redirect_to', FILTER_SANITIZE_ENCODED) : false;
 			$activation_link                = add_query_arg(
 				array(
 					'swpm_email_activation' => '1',
 					'swpm_member_id'        => $member_id,
 					'swpm_token'            => $act_code,
+					'swpm_redirect_to'      => $swpm_redirect_to,
 				),
 				get_home_url()
 			);

--- a/simple-membership/classes/class.swpm-self-action-handler.php
+++ b/simple-membership/classes/class.swpm-self-action-handler.php
@@ -54,6 +54,17 @@ class SwpmSelfActionHandler {
         if (!empty($enable_auto_login)){
             SwpmLog::log_simple_debug("Auto login after registration feature is enabled in settings. Performing auto login for user: " . $user_data['user_name'], true);
             $login_page_url = SwpmSettings::get_instance()->get_value('login-page-url');
+
+            // If exist, get the swpm_redirect_to parameter, and add it to the login_page_url variable to allow future redirections
+            $swpm_redirect_to = !empty($_GET['swpm_redirect_to']) ? filter_input(INPUT_GET, 'swpm_redirect_to', FILTER_SANITIZE_ENCODED) : false;
+
+            $login_page_url = add_query_arg(
+                array(
+                    'swpm_redirect_to' => $swpm_redirect_to,
+                ),
+                $login_page_url
+            );
+
             $encoded_pass = base64_encode($user_data['plain_password']);
             $swpm_auto_login_nonce = wp_create_nonce('swpm-auto-login-nonce');
             $arr_params = array(


### PR DESCRIPTION
Hi,

In the case of my website, I need to be able to redirect the user to different custom pages after the registration, so I tried to use the parameter `swpm_redirect_to`, that is provided with the plugin `simple-membership-after-login-redirection`

But I've realized that this parameter was not forwarded in the account activation link that is sent by email, and it was also not supported on the page that is receiving the clicks from the email activation link.

So in this PR, I've added support for the `swpm_redirect_to`.

That will allow to keep the variable `swpm_redirect_to` during the whole account registration/activation journey :)

Example of URL to create an account with automatic redirection after account activation :
https://mywebsite.test/register/?swpm_redirect_to=%2Fcustom-page-to-redirect-to

Thanks

Thomas