### PR TITLE
Added apply_filters to allow custom redirections

### DIFF
--- a/simple-membership/classes/class.swpm-front-registration.php
+++ b/simple-membership/classes/class.swpm-front-registration.php
@@ -169,6 +169,10 @@ class SwpmFrontRegistration extends SwpmRegistration {
 				);
 			} else {
 				$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
+
+				// Allow hooks to change the value of login_page_url
+				$login_page_url = apply_filters('swpm_register_front_end_login_page_url', $login_page_url);
+
 				$after_rego_msg = '<div class="swpm-registration-success-msg">' . SwpmUtils::_( 'Registration Successful. ' ) . SwpmUtils::_( 'Please' ) . ' <a href="' . $login_page_url . '">' . SwpmUtils::_( 'Login' ) . '</a></div>';
 				$after_rego_msg = apply_filters( 'swpm_registration_success_msg', $after_rego_msg );
 				$message        = array(
@@ -441,6 +445,9 @@ class SwpmFrontRegistration extends SwpmRegistration {
 	public function email_activation() {
 		$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
 
+		// Allow hooks to change the value of login_page_url
+		$login_page_url = apply_filters('swpm_email_activation_login_page_url', $login_page_url);
+
 		$member_id = FILTER_INPUT( INPUT_GET, 'swpm_member_id', FILTER_SANITIZE_NUMBER_INT );
 
 		$member = SwpmMemberUtils::get_user_by_id( $member_id );
@@ -490,6 +497,9 @@ class SwpmFrontRegistration extends SwpmRegistration {
 
 	public function resend_activation_email() {
 		$login_page_url = SwpmSettings::get_instance()->get_value( 'login-page-url' );
+
+		// Allow hooks to change the value of login_page_url
+		$login_page_url = apply_filters('swpm_resend_activation_email_login_page_url', $login_page_url);
 
 		$member_id = FILTER_INPUT( INPUT_GET, 'swpm_member_id', FILTER_SANITIZE_NUMBER_INT );
 

--- a/simple-membership/classes/class.swpm-registration.php
+++ b/simple-membership/classes/class.swpm-registration.php
@@ -45,6 +45,10 @@ abstract class SwpmRegistration {
 				),
 				get_home_url()
 			);
+
+			// Allow hooks to change the value of activation_link
+			$activation_link = apply_filters('swpm_send_reg_email_activation_link', $activation_link);
+
 			$member_info['activation_link'] = $activation_link;
 		}
 

--- a/simple-membership/classes/class.swpm-self-action-handler.php
+++ b/simple-membership/classes/class.swpm-self-action-handler.php
@@ -54,6 +54,10 @@ class SwpmSelfActionHandler {
         if (!empty($enable_auto_login)){
             SwpmLog::log_simple_debug("Auto login after registration feature is enabled in settings. Performing auto login for user: " . $user_data['user_name'], true);
             $login_page_url = SwpmSettings::get_instance()->get_value('login-page-url');
+
+            // Allow hooks to change the value of login_page_url
+            $login_page_url = apply_filters('swpm_after_reg_callback_login_page_url', $login_page_url);
+
             $encoded_pass = base64_encode($user_data['plain_password']);
             $swpm_auto_login_nonce = wp_create_nonce('swpm-auto-login-nonce');
             $arr_params = array(


### PR DESCRIPTION
Hi,

As agreed, I have moved the new feature to enable custom redirections using **swpm_redirect_to** into the plugin **SWPM After Login Redirection**.

In order for this new feature to work in **SWPM After Login Redirection**, we need to add some **apply_filters** to the main Simple Membership plugin, and that is what this PR is for.

Since I've not been able to find the Github repository for the plugin **SWPM After Login Redirection**, I've created a repository using the version 1.4 that I found on Wordpress.org, and applied the changes.

The changes are visible here :
https://github.com/Th0masL/simple-membership-after-login-redirection/compare/swpm_redirect_to_support

Feel free to add those changes to the official **SWPM After Login Redirection** plugin, if you want to.

When enabling this new functionality in **SWPM After Login Redirection**, the behavior will be the following :
- if the email validation is enabled, the _activate account link_ in the email will contain the value of **swpm_redirect_to** value (if it was present during the registration page)
- if the email validation is not enabled, and _automatic login after registration_ is enabled, it will automatically redirect to the value of **swpm_redirect_to** (if it was present during the registration page)
- if the email validation is not enabled, and _automatic login after registration_ is not enabled, the link that is visible on the page, where the user can click to log in, contains the swpm_redirect_to (if it was present during the registration page)

Also, there is an additional option in **SWPM After Login Redirection** that allow user to enable/disable this new functionality. 

Thanks

Thomas

