### PR TITLE
Simple fix that populate the correct variable with the Customer IP when using Paypal

### DIFF
--- a/simple-membership/ipn/swpm_handle_pp_ipn.php
+++ b/simple-membership/ipn/swpm_handle_pp_ipn.php
@@ -222,6 +222,12 @@ class swpm_paypal_ipn_handler { // phpcs:ignore
 		$this->debug_log( 'Saving transaction data to the database table.', true );
 		$this->ipn_data['gateway'] = 'paypal';
 		$this->ipn_data['status']  = $this->ipn_data['payment_status'];
+
+		// If the value ipn_data['ip'] is empty, try to detect the customer IP address using the variable custom['user_ip']
+		if (empty($this->ipn_data['ip']) && filter_var($customvariables['user_ip'], FILTER_VALIDATE_IP)) {
+			$this->ipn_data['ip'] = $customvariables['user_ip'];
+		}
+
 		SwpmTransactions::save_txn_record( $this->ipn_data, $cart_items );
 		$this->debug_log( 'Transaction data saved.', true );
 


### PR DESCRIPTION
Hi,

It looks like the IP Address was never detected correctly when the customer is paying with Paypal, because the PHP code was expecting to find the IP address in the variable `$ipn['ip']`, but this variable is always empty when receiving the payment response from Paypal.

Instead, we can use the variable `$ipn_data['custom']` which contains an array of variables that has been set by SWPM when initializing the Paypal payment, and it contains the user IP, saved as `['user_ip']`.

Here is an overview before and after (The payment of user 46 is using this PR).

```
# mysql wp_testwp04 -e "SELECT id,first_name,member_id,txn_date,txn_id,payment_amount,gateway,status,ip_address FROM wp_swpm_payments_tbl"
+----+------------+-----------+------------+-------------------+----------------+---------+-----------+-----------------+
| id | first_name | member_id | txn_date   | txn_id            | payment_amount | gateway | status    | ip_address      |
+----+------------+-----------+------------+-------------------+----------------+---------+-----------+-----------------+
| 45 | John       | 4         | 2020-09-29 | 9176661881570324V | 239.00         | paypal  | Completed |                 |
| 46 | Rick       | 5         | 2020-09-29 | 56L51513TD6776402 | 239.00         | paypal  | Completed | 195.50.XXX.YYY  |
+----+------------+-----------+------------+-------------------+----------------+---------+-----------+-----------------+
```

Thanks

Thomas