### PR TITLE
Add Action Hook for Password Reset via Link

### DIFF
--- a/simple-membership/classes/class.swpm-front-registration.php
+++ b/simple-membership/classes/class.swpm-front-registration.php
@@ -555,6 +555,9 @@ class SwpmFrontRegistration extends SwpmRegistration {
 
 		SwpmLog::log_simple_debug( 'Member password has been reset. Email: ' . $email, true );
 
+		//Trigger action hook
+		do_action( 'swpm_front_end_reset_password_using_link_completed', $user_data, $password);
+
 		return true;
 	}
 


### PR DESCRIPTION
Title: Add Action Hook for Password Reset via Link

Description:

In the context of our website being linked to another service using OAuth2, for our case it is essential to trigger action whenever a user's password is changed via a password reset link and i think it's usefull for others.

Currently, we have action hooks in place for user profile edits and admin user edits, namely 'swpm_front_end_profile_edited' and 'swpm_admin_end_edit_complete_user_data,' respectively.

I propose adding a new action hook for password reset using a link. This new hook will be structured as follows:

do_action( 'swpm_front_end_reset_password_using_link_completed', $user_data, $password);
