### PR TITLE
fpassthru fix

### DIFF
--- a/simple-membership/classes/class.swpm-log.php
+++ b/simple-membership/classes/class.swpm-log.php
@@ -56,7 +56,13 @@ class SwpmLog {
 			wp_die( 'Can\'t open the log file.' );
 		}
 		header( 'Content-Type: text/plain' );
-		fpassthru( $fp );
+
+		if ( function_exists( 'fpassthru' ) ) {
+			fpassthru( $fp );
+		} else {
+			echo stream_get_contents( $fp );
+		}
+
 		die;
 	}
 


### PR DESCRIPTION
Some systems disable fpassthru for security reasons; using stream_get_ontents instead if fpassthru is unavailable when printing the debug log.